### PR TITLE
Touchup and bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+project/project
+target/

--- a/src/main/scala/org/scalaml/core/functional/Functor.scala
+++ b/src/main/scala/org/scalaml/core/functional/Functor.scala
@@ -91,16 +91,19 @@ trait BiFunctor[M[_, _]] {
 		 * @author Patrick Nicolas
 		 * @version 0.99
 		 */
-trait BiProdFunctor[M[_, _], N[_,_]]  
+trait BiProdFunctor[M[_, _], N[_,_]]
+    // TODO: find a way to avoid structural types here
 		extends BiFunctor[({type L[X, Y] = (M[X, Y], N[X, Y])})#L ] {
-		// abstract values
+
+	// abstract values
 	val bf: BiFunctor[M]
-			val bg: BiFunctor[N]
+	val bg: BiFunctor[N]
 	
 	
 	override def map[U, V, W, Z]
 			(mnuv: (M[U, V], N[U,V]))
-			(fuw: U => W, fvz: V => Z): (M[W, Z], N[W,Z]) = 
+			(fuw: U => W, fvz: V => Z): (M[W, Z], N[W,Z]) =
+  // TODO: Use destructuring bindings instead of _1, _2
 		(bf.map(mnuv._1)(fuw, fvz), bg.map(mnuv._2)(fuw, fvz))
 } 
 

--- a/src/main/scala/org/scalaml/core/functional/HomFunctor.scala
+++ b/src/main/scala/org/scalaml/core/functional/HomFunctor.scala
@@ -25,17 +25,17 @@ object TensorFunctor {
      * Definition of the Functor for the the vector field. The transformation is implemented
      * through a covariant functor 'map'
      */
-  
+  // TODO: convert to use of type classes
   type Hom[T] = {
-    type Right[X] = Function1[X,T]
-    type Left[X] = Function1[T,X]
+    type Right[X] = X=>T
+    type Left[X] = T=>X
   }
   
   
   trait VectorFtor[T] extends Functor[(Hom[T])#Left] { 
     self =>
-      override def map[U,V](vu: Function1[T,U])(f: U =>V): 
-        Function1[T,V] = f.compose(vu)
+      override def map[U,V](vu: T => U)(f: U =>V):
+        T=>V = f.compose(vu)
   }
 
   
@@ -51,14 +51,14 @@ object TensorFunctor {
   
   trait CoVectorFtor[T] extends CoFunctor[(Hom[T])#Right] {
     self =>
-      override def map[U,V](vu: Function1[U,T])(f: V =>U): 
-         Function1[V,T] = f.andThen(vu)
+      override def map[U,V](vu: U=>T)(f: V =>U):
+         V=>T = f.andThen(vu)
   }
   
-  implicit class coVector2Ftor[U, T](vu: Function1[U, T]) extends CoVectorFtor[T] {
-    final def map[V](f: V => U): Function1[V, T] = super.map(vu)(f) 
+  implicit class coVector2Ftor[U, T](vu: U=>T) extends CoVectorFtor[T] {
+    final def map[V](f: V => U): V=>T = super.map(vu)(f)
         
-    def compose[V, W](f: V => U, g: W => V): Function1[W, T] = super.map(vu)(f).map(g)
+    def compose[V, W](f: V => U, g: W => V): W=>T = super.map(vu)(f).map(g)
   }
 }
 

--- a/src/main/scala/org/scalaml/core/types.scala
+++ b/src/main/scala/org/scalaml/core/types.scala
@@ -49,6 +49,7 @@ object Types {
 		type DblPairVector = Vector[DblPair]
 		
 		type XSeries[T] = Vector[T]
+    // TODO: Why not Vector[Vector[T]]?
 		type XVSeries[T] = Vector[Array[T]]
 
 		case class Pair(val p: DblPair) {
@@ -102,7 +103,9 @@ object Types {
 			  v.zipWithIndex.map{ case(x ,n) => s"${x}:${n}"}.mkString(", ")
 
 			else
-			  v.mkString(", ").dropRight(1)
+        v.mkString(", ")
+			// TODO: This can't be right, just drops last character. mkString doesn't append a final comma or space.
+			  //v.mkString(", ").dropRight(1)
 		}
 
 		/**

--- a/src/main/scala/org/scalaml/util/MathUtils.scala
+++ b/src/main/scala/org/scalaml/util/MathUtils.scala
@@ -52,9 +52,9 @@ object MathUtils {
 	@implicitNotFound(msg = "DMatrix  Conversion from type $T to Double is undefined")
 	class DMatrix(
 			val nRows: Int, 
-			val nCols: Int, 
+			val nCols: Int,
 			val data: DblArray) {
-	  
+
 		import DMatrix._
 		check(nRows, nCols, data)
 		
@@ -69,7 +69,7 @@ object MathUtils {
 		final def apply(i: Int, j: Int): Double = {
 			require(i < nRows, s"Matrix.apply Row index $i should be < $nRows")
 			require(j < nCols, s"Matrix.apply Column index $j should be < $nCols")
-			data(i*nCols+j)
+			data(i * nCols + j)
 		}
 	
 			/**
@@ -131,7 +131,7 @@ object MathUtils {
 			
 			val i = iRow*nCols		
 			Range(0, nCols).foreach(k => {
-				val old = data(i+k)
+				val old = data(i + k)
 				data.update(i + k, old/t) 
 			})
 			this
@@ -148,15 +148,15 @@ object MathUtils {
 			require(i >= 0 & i < nRows, s"Matrix.+= Row index $i is out of bounds ")
 			require(j >= 0 & j < nCols, s"Matrix.+= Column index $j is out of bounds ")
 			
-			val index = i*nCols +j
-			data.update(index, data(index)+ t)
+			val index = i * nCols + j
+			data.update(index, data(index) + t)
 			this
 		}
 		
 		def update(i: Int, j : Int, t: Double): this.type = {
 			require(i >= 0 & i < nRows, s"Matrix.+= Row index $i is out of bounds ")
 			require(j >= 0 & j < nCols, s"Matrix.+= Column index $j is out of bounds ")
-			data.update(i*nCols +j, t)
+			data.update(i * nCols + j, t)
 			this
 		}
 	
@@ -174,7 +174,7 @@ object MathUtils {
 			require(j >= 0 & j < nCols, s"Matrix.+= Column index $j is out of bounds ")
 			
 			val newData = data.clone
-			val index = i*nCols +j
+			val index = i * nCols + j
 			newData.update(index, data(index) + t)
 			new DMatrix(nRows,nCols, newData)
 		}
@@ -192,7 +192,7 @@ object MathUtils {
 			val i = iRow*nCols
 			
 			Range(0, nCols).foreach(k => {
-				val old = data(i+k)
+				val old = data(i + k)
 				data.update(i + k, old + t) 
 			})
 		}
@@ -200,7 +200,7 @@ object MathUtils {
 		@throws(classOf[IllegalArgumentException])
 		def update(iRow: Int, t: Double): Unit = {
 		  require(iRow >= 0 & iRow < nRows, s"Matrix.+= row index $iRow is out of bounds ")
-			val i = iRow*nCols
+			val i = iRow * nCols
 			Range(0, nCols).foreach(k => data.update(i + k, t)  )
 		}
 			/**
@@ -211,8 +211,8 @@ object MathUtils {
 			val m = DMatrix(nCols, nRows)
 			
 			Range(0, nRows).foreach(i => {
-				val col = i*nCols
-				Range(0, nCols).foreach(j => m += (j, i, data(col+j)))
+				val col = i * nCols
+				Range(0, nCols).foreach(j => m += (j, i, data(col + j)))
 			})
 			m
 		}
@@ -221,7 +221,7 @@ object MathUtils {
 		   * Return the total number of elements in the matrix
 		   */
 		@inline
-		final def size = nRows*nCols
+		final def size: Int = nRows * nCols
 	
 			/**
 			 * Method that normalizes the rows of a matrix so the sum of values is 1.0. This method

--- a/src/test/scala/org/scalaml/app/chap1/PlotterEval.scala
+++ b/src/test/scala/org/scalaml/app/chap1/PlotterEval.scala
@@ -50,7 +50,7 @@ object PlotterEval extends Eval {
 	private val VOL_COLUMN_INDEX = 5
 	private val HIGH_INDEX = 2
 	private val LOW_INDEX = 3
-	private val pathName = "resources/data/chap1/CSCO.csv"
+	private val pathName = "resources/data/Chap1/CSCO.csv"
     
  
 		/**


### PR DESCRIPTION
Several small touchups after initial review and execution of first step of Chap1 tests:
- add .gitignore for execution/Intell-J generated files
- fix up spacing, removing tabs when found in files
- add TODO where finding style or other IDE warnings but not ready to fix
- replace Function1[A,B] usage with A=>B
- BUG - fixed dropRight(1) problem in types.scala mkString usage
- fix spacing around math operators per style guide
- specify return type for public function size in MathUtils for matrix
- use Chap1 for folder name per linux git clone results
- introduce named values to replace magic numbers, although it seems a bit egregious when used with the Enumerator mappers, which themselves may be better served as sealed case classes.
- use some destructuring bindings instead of _1, _2
- rename some vars to be more specific to the contained used case such as normTestValue0 -> normTestValueVolatility
- breakup long lines per style guide
- breakup extended function calls per referenced Effective Scala advice

Note that actual 'bugs' include the dropRight instance and chap1 vs Chap1
